### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol server for analyzing claims, validating sources, and detecting manipulation using multiple epistemological frameworks.
 
+<a href="https://glama.ai/mcp/servers/isszli7z1y"><img width="380" height="200" src="https://glama.ai/mcp/servers/isszli7z1y/badge" alt="Anti-Bullshit Server MCP server" /></a>
+
 ## Features
 
 The server provides three main tools for detecting and analyzing bullshit:


### PR DESCRIPTION
This PR adds a badge for the [Anti-Bullshit MCP Server](https://glama.ai/mcp/servers/isszli7z1y) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/isszli7z1y"><img width="380" height="200" src="https://glama.ai/mcp/servers/isszli7z1y/badge" alt="Anti-Bullshit Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.